### PR TITLE
[implant] Clean the start and end of the command for cmd executor (#18)

### DIFF
--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -51,7 +51,7 @@ pub fn invoke_windows_command(command: &str) -> std::io::Result<Output> {
     // \n can be found in Windows path (ex: C:\\newFile) but \n replaces only break line and not \\n in path
     let new_command = format!(
         "setlocal & {} & if errorlevel 1 exit /b 1",
-        command.replace("\n", " & ")
+        command.trim().replace("\n", " & ") // trim "cleans" the start and the end of the command (see the trim doc)
     );
     let invoke_expression = format!("([System.Text.Encoding]::UTF8.GetString([convert]::FromBase64String(\"{}\")))", BASE64_STANDARD.encode(new_command));
     let base64_child = Command::new("powershell.exe")


### PR DESCRIPTION
### Proposed changes

* Clean the start and end of the command for cmd executor because in some payloads, there are lines breaks at the end.

### Related issues

* https://github.com/OpenBAS-Platform/implant/issues/18

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

To test, look at the notion page "implant" to generate an implant for your local dev env.
