### PR TITLE
Add a check of the executors at the implant level before executing the commands Issue/12

### DIFF
--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -114,8 +114,8 @@ pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Resu
     let mut formatted_cmd= decode_command(command);
     let mut args: Vec<&str> = vec!["-c"];
 
-    if !is_executor_present(executor){
-        return Err(Error::Internal(format!("Executor {} is not available.", executor)));
+    if !is_executor_present(final_executor){
+        return Err(Error::Internal(format!("Executor {} is not available.", final_executor)));
     }
 
     if final_executor == "cmd" {

--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -135,6 +135,7 @@ pub fn invoke_unix_command(command: &str, executor: &str) -> std::io::Result<Out
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Result<ExecutionResult, Error> {
+
     let invoke_output;
     if executor == "bash" {
         if !is_executor_present(executor){

--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -135,10 +135,6 @@ pub fn invoke_unix_command(command: &str, executor: &str) -> std::io::Result<Out
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Result<ExecutionResult, Error> {
-    if !is_executor_present(executor){
-        return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
-    }
-
     let invoke_output;
     if executor == "bash" {
         if !is_executor_present(executor){

--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -5,6 +5,7 @@ use base64::prelude::BASE64_STANDARD;
 use serde::Deserialize;
 
 use crate::common::error_model::Error;
+use crate::process::exec_utils::is_executor_present;
 
 #[derive(Debug, Deserialize)]
 pub struct ExecutionResult {
@@ -89,6 +90,10 @@ pub fn manage_result(invoke_output: Output, pre_check: bool) -> Result<Execution
 
 #[cfg(target_os = "windows")]
 pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Result<ExecutionResult, Error> {
+    if !is_executor_present(executor){
+        return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
+    }
+
     let invoke_output;
     if executor == "cmd" {
         invoke_output = invoke_windows_command(command);
@@ -125,6 +130,10 @@ pub fn invoke_unix_command(command: &str, executor: &str) -> std::io::Result<Out
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Result<ExecutionResult, Error> {
+    if !is_executor_present(executor){
+        return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
+    }
+
     let invoke_output;
     if executor == "bash" {
         invoke_output = invoke_unix_command(command, "bash");

--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -141,7 +141,7 @@ pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Resu
         if !is_executor_present(executor){
             return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
         }
-        invoke_output = invoke_unix_command(command, "bash");
+        invoke_output = invoke_unix_command(command, executor);
     } else if executor == "psh" {
         if !is_executor_present(executor){
             return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));

--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -90,16 +90,21 @@ pub fn manage_result(invoke_output: Output, pre_check: bool) -> Result<Execution
 
 #[cfg(target_os = "windows")]
 pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Result<ExecutionResult, Error> {
-    if !is_executor_present(executor){
-        return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
-    }
-
     let invoke_output;
     if executor == "cmd" {
+        if !is_executor_present(executor){
+            return Err(Error::Internal(format!("Executor {} is not available.", executor)));
+        }
         invoke_output = invoke_windows_command(command);
     } else if executor == "bash" || executor == "sh" {
+        if !is_executor_present(executor){
+            return Err(Error::Internal(format!("Executor {} is not available.", executor)));
+        }
         invoke_output = invoke_shell_command(command, executor);
     } else {
+        if !is_executor_present("powershell.exe"){
+            return Err(Error::Internal(format!("Executor powershell.exe is not available.")));
+        }
         invoke_output = invoke_powershell_command(command,"powershell.exe", &[
             "-ExecutionPolicy",
             "Bypass",
@@ -136,8 +141,14 @@ pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Resu
 
     let invoke_output;
     if executor == "bash" {
+        if !is_executor_present(executor){
+            return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
+        }
         invoke_output = invoke_unix_command(command, "bash");
     } else if executor == "psh" {
+        if !is_executor_present(executor){
+            return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
+        }
         invoke_output = invoke_powershell_command(command, "powershell", &[
             "-ExecutionPolicy",
             "Bypass",
@@ -145,6 +156,9 @@ pub fn command_execution(command: &str, executor: &str, pre_check: bool) -> Resu
             "-NoProfile",
             "-Command"]);
     } else {
+        if !is_executor_present("sh"){
+            return Err(Error::Internal(format!("Executor sh is not available.")));
+        }
         invoke_output = invoke_unix_command(command, "sh");
     }
     manage_result(invoke_output?, pre_check)

--- a/src/process/exec_utils.rs
+++ b/src/process/exec_utils.rs
@@ -4,8 +4,8 @@ use std::process::Command;
 
 
 pub fn is_executor_present(executor: &str) -> bool {
-    Command::new(actual_executor)
+    Command::new(executor)
         .spawn()
-        .map(|mut child| child.kill().is_ok()) // Kill immediately to avoid hanging.
+        .map(|mut child| child.kill().is_ok())
         .unwrap_or(false)
 }

--- a/src/process/exec_utils.rs
+++ b/src/process/exec_utils.rs
@@ -11,7 +11,7 @@ pub fn is_executor_present(executor: &str) -> bool {
     ]);
     let actual_executor = alias_map.get(executor).unwrap_or(&executor);
 
-    Command::new(executor)
+    Command::new(actual_executor)
         .spawn()
         .map(|mut child| child.kill().is_ok()) // Kill immediately to avoid hanging.
         .unwrap_or(false)

--- a/src/process/exec_utils.rs
+++ b/src/process/exec_utils.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+use std::process::Command;
+
+
+
+pub fn is_executor_present(executor: &str) -> bool {
+    // add a mapping to get the executor name, if not in the map we use the parameter
+    let alias_map: HashMap<&str, &str> = HashMap::from([
+        ("psh", "powershell"),
+    ]);
+    let actual_executor = alias_map.get(executor).unwrap_or(&executor);
+
+    //run a simple command to check the executor
+    let output = Command::new(actual_executor)
+        .arg("echo Hello")
+        .output();
+    output.map(|o| o.status.success()).unwrap_or(false)
+}

--- a/src/process/exec_utils.rs
+++ b/src/process/exec_utils.rs
@@ -4,13 +4,6 @@ use std::process::Command;
 
 
 pub fn is_executor_present(executor: &str) -> bool {
-
-    // add a mapping to get the executor name, if not in the map we use the parameter
-    let alias_map: HashMap<&str, &str> = HashMap::from([
-        ("psh", "powershell"),
-    ]);
-    let actual_executor = alias_map.get(executor).unwrap_or(&executor);
-
     Command::new(actual_executor)
         .spawn()
         .map(|mut child| child.kill().is_ok()) // Kill immediately to avoid hanging.

--- a/src/process/exec_utils.rs
+++ b/src/process/exec_utils.rs
@@ -11,9 +11,8 @@ pub fn is_executor_present(executor: &str) -> bool {
     ]);
     let actual_executor = alias_map.get(executor).unwrap_or(&executor);
 
-    //run a simple command to check the executor
-    let output = Command::new(actual_executor)
-        .arg("echo Hello")
-        .output();
-    output.map(|o| o.status.success()).unwrap_or(false)
+    Command::new(executor)
+        .spawn()
+        .map(|mut child| child.kill().is_ok()) // Kill immediately to avoid hanging.
+        .unwrap_or(false)
 }

--- a/src/process/exec_utils.rs
+++ b/src/process/exec_utils.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 
 
 pub fn is_executor_present(executor: &str) -> bool {
+
     // add a mapping to get the executor name, if not in the map we use the parameter
     let alias_map: HashMap<&str, &str> = HashMap::from([
         ("psh", "powershell"),

--- a/src/process/file_exec.rs
+++ b/src/process/file_exec.rs
@@ -72,7 +72,7 @@ pub fn file_execution(filename: &str) -> Result<ExecutionResult, Error> {
     let script_file_name = compute_working_file(filename);
     // Prepare and execute the command
     let command_args = &[script_file_name.to_str().unwrap()];
-    let invoke_output = Command::new("bash")
+    let invoke_output = Command::new(executor)
         .args(command_args)
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src/process/file_exec.rs
+++ b/src/process/file_exec.rs
@@ -4,6 +4,7 @@ use std::process::{Command, Output, Stdio};
 
 use crate::common::error_model::Error;
 use crate::process::command_exec::ExecutionResult;
+use crate::process::exec_utils::is_executor_present;
 
 fn compute_working_file(filename: &str) -> PathBuf {
     let current_exe_patch = env::current_exe().unwrap();
@@ -37,7 +38,10 @@ pub fn manage_result(invoke_output: Output) -> Result<ExecutionResult, Error>  {
 
 #[cfg(target_os = "windows")]
 pub fn file_execution(filename: &str) -> Result<ExecutionResult, Error> {
-
+    let executor = "powershell.exe";
+    if !is_executor_present(executor){
+        return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
+    }
     let script_file_name = compute_working_file(filename);
     let win_path = format!("$ErrorActionPreference = 'Stop'; & '{}'; exit $LASTEXITCODE", script_file_name.to_str().unwrap());
     let command_args = &[
@@ -49,7 +53,7 @@ pub fn file_execution(filename: &str) -> Result<ExecutionResult, Error> {
         "-NoProfile",
         "-Command",
     ];
-    let invoke_output = Command::new("powershell.exe")
+    let invoke_output = Command::new(executor)
         .args(command_args)
         .arg(win_path)
         .stderr(Stdio::piped())
@@ -61,6 +65,10 @@ pub fn file_execution(filename: &str) -> Result<ExecutionResult, Error> {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn file_execution(filename: &str) -> Result<ExecutionResult, Error> {
+    let executor = "bash";
+    if !is_executor_present(executor){
+        return Err(Error::Internal(format!("Executor '{}' is not available.", executor)));
+    }
     let script_file_name = compute_working_file(filename);
     // Prepare and execute the command
     let command_args = &[script_file_name.to_str().unwrap()];

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1,2 +1,3 @@
 pub mod command_exec;
 pub mod file_exec;
+pub mod exec_utils;


### PR DESCRIPTION


### Proposed changes

* Adding a check to verify if the executor is installed -> today we also need powershell to use cmd but I am not veryfying that powershell is installed as it will be removed in another CR
*

### Related issues
* issue  #12 
*

### Checklist


- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
