### PR TITLE
[implant] catch permissionDenied error on command execution

### DIFF
--- a/src/process/command_exec.rs
+++ b/src/process/command_exec.rs
@@ -46,7 +46,7 @@ pub fn invoke_command(
                 stderr: format!("{}", e).into_bytes(),
             })
         }
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }
 


### PR DESCRIPTION
### Description

If the process fails due to privilege access, .spawn() immediately returns an Err and never creates a process, meaning wait_with_output() is never called. As a result, the application crashes, and the error is not caught properly.

### Proposed changes

* catch PermissionDenied error and handle it instead of crashing. 

### Related issues

*Close: [2575](https://github.com/OpenBAS-Platform/openbas/issues/2575)
