### PR TITLE
[implant] Add retry to update status if client error

### DIFF
--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -1,5 +1,6 @@
 use super::Client;
 use crate::common::error_model::Error;
+use log::info;
 use mailparse::{parse_content_disposition, parse_header};
 use reqwest::blocking::Response;
 use reqwest::header::CONTENT_DISPOSITION;
@@ -11,7 +12,6 @@ use std::path::PathBuf;
 use std::thread::sleep;
 use std::time::Duration;
 use std::{env, fs, io};
-use log::info;
 
 pub fn write_response<W>(writer: W, response: reqwest::blocking::Response) -> std::io::Result<u64>
 where
@@ -152,7 +152,7 @@ impl Client {
                 .map_err(|e| Error::Internal(e.to_string()))
         } else if response.status().is_client_error() && retry > 0 {
             sleep(Duration::from_secs(1));
-            info!("retry {:?} ", retry);
+            info!("retry {retry:?} ");
             self.update_status_retry(inject_id, agent_id, input, retry - 1)
         } else {
             let msg = response

--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use std::thread::sleep;
 use std::time::Duration;
 use std::{env, fs, io};
+use log::info;
 
 pub fn write_response<W>(writer: W, response: reqwest::blocking::Response) -> std::io::Result<u64>
 where
@@ -151,6 +152,7 @@ impl Client {
                 .map_err(|e| Error::Internal(e.to_string()))
         } else if response.status().is_client_error() && retry > 0 {
             sleep(Duration::from_secs(1));
+            info!("retry {:?} ", retry);
             self.update_status_retry(inject_id, agent_id, input, retry - 1)
         } else {
             let msg = response

--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -1,3 +1,4 @@
+use super::Client;
 use crate::common::error_model::Error;
 use mailparse::{parse_content_disposition, parse_header};
 use reqwest::blocking::Response;
@@ -7,9 +8,9 @@ use serde_json::json;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
+use std::thread::sleep;
+use std::time::Duration;
 use std::{env, fs, io};
-
-use super::Client;
 
 pub fn write_response<W>(writer: W, response: reqwest::blocking::Response) -> std::io::Result<u64>
 where
@@ -111,6 +112,16 @@ impl Client {
         agent_id: String,
         input: UpdateInput,
     ) -> Result<UpdateInjectResponse, Error> {
+        self.update_status_retry(inject_id, agent_id, input, 5)
+    }
+
+    fn update_status_retry(
+        &self,
+        inject_id: String,
+        agent_id: String,
+        input: UpdateInput,
+        retry: u64,
+    ) -> Result<UpdateInjectResponse, Error> {
         let post_data = json!(input);
         match self
             .post(&format!(
@@ -120,18 +131,34 @@ impl Client {
             .send()
         {
             Ok(response) => {
-                if response.status().is_success() {
-                    response
-                        .json::<UpdateInjectResponse>()
-                        .map_err(|e| Error::Internal(e.to_string()))
-                } else {
-                    let msg = response
-                        .text()
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    Err(Error::Api(msg))
-                }
+                self.update_status_response(response, inject_id, agent_id, input, retry)
             }
             Err(err) => Err(Error::Internal(err.to_string())),
+        }
+    }
+
+    fn update_status_response(
+        &self,
+        response: Response,
+        inject_id: String,
+        agent_id: String,
+        input: UpdateInput,
+        retry: u64,
+    ) -> Result<UpdateInjectResponse, Error> {
+        if response.status().is_success() {
+            response
+                .json::<UpdateInjectResponse>()
+                .map_err(|e| Error::Internal(e.to_string()))
+        } else {
+            if response.status().is_client_error() && retry > 0 {
+                sleep(Duration::from_secs(1));
+                self.update_status_retry(inject_id, agent_id, input, retry - 1)
+            } else {
+                let msg = response
+                    .text()
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                Err(Error::Api(msg))
+            }
         }
     }
 

--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -149,16 +149,14 @@ impl Client {
             response
                 .json::<UpdateInjectResponse>()
                 .map_err(|e| Error::Internal(e.to_string()))
+        } else if response.status().is_client_error() && retry > 0 {
+            sleep(Duration::from_secs(1));
+            self.update_status_retry(inject_id, agent_id, input, retry - 1)
         } else {
-            if response.status().is_client_error() && retry > 0 {
-                sleep(Duration::from_secs(1));
-                self.update_status_retry(inject_id, agent_id, input, retry - 1)
-            } else {
-                let msg = response
-                    .text()
-                    .unwrap_or_else(|_| "Unknown error".to_string());
-                Err(Error::Api(msg))
-            }
+            let msg = response
+                .text()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(Error::Api(msg))
         }
     }
 

--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -152,7 +152,7 @@ impl Client {
                 .map_err(|e| Error::Internal(e.to_string()))
         } else if response.status().is_client_error() && retry > 0 {
             sleep(Duration::from_secs(1));
-            info!("retry {retry:?} ");
+            info!("retry {retry:?} to update status for inject id: {inject_id:?} and agent id: {agent_id:?}");
             self.update_status_retry(inject_id, agent_id, input, retry - 1)
         } else {
             let msg = response

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-use std::env;
-use std::sync::atomic::AtomicBool;
-use std::time::{Instant};
 use clap::Parser;
 use log::info;
 use rolling_file::{BasicRollingFileAppender, RollingConditionBasic};
+use std::env;
+use std::sync::atomic::AtomicBool;
+use std::time::Instant;
 
 use crate::api::manage_inject::{InjectorContractPayload, UpdateInput};
 use crate::api::Client;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::sync::atomic::AtomicBool;
-
+use std::time::{Instant};
 use clap::Parser;
 use log::info;
 use rolling_file::{BasicRollingFileAppender, RollingConditionBasic};
@@ -53,6 +53,7 @@ pub fn handle_payload(
     agent_id: String,
     api: &Client,
     contract_payload: &InjectorContractPayload,
+    duration: Instant,
 ) {
     let mut prerequisites_code = 0;
     let mut execution_message = "Payload completed";
@@ -117,7 +118,7 @@ pub fn handle_payload(
                     UpdateInput {
                         execution_message: String::from("Payload execution type not supported."),
                         execution_status: String::from("ERROR"),
-                        execution_duration: 0,
+                        execution_duration: duration.elapsed().as_millis(),
                         execution_action: String::from("complete"),
                     },
                 );
@@ -153,7 +154,7 @@ pub fn handle_payload(
         UpdateInput {
             execution_message: String::from(execution_message),
             execution_status: String::from(execution_status),
-            execution_duration: 0,
+            execution_duration: duration.elapsed().as_millis(),
             execution_action: String::from("complete"),
         },
     );
@@ -161,6 +162,7 @@ pub fn handle_payload(
 
 fn main() -> Result<(), Error> {
     // region Init logger
+    let duration = Instant::now();
     let current_exe_patch = env::current_exe().unwrap();
     let parent_path = current_exe_patch.parent().unwrap();
     let log_file = parent_path.join(PREFIX_LOG_NAME);
@@ -189,6 +191,7 @@ fn main() -> Result<(), Error> {
         args.agent_id.clone(),
         &api,
         &contract_payload,
+        duration,
     );
     // endregion
     Ok(())


### PR DESCRIPTION
### Proposed changes

* Sometimes, inject stays in PENDING because the implant is too fast for OpenBAS Backend so we add a retry to update status if OpenBAS send an error to the implant.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
