### PR TITLE
[backend] Fix file name with special char

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tracing-appender = "0.2.3"
 rolling-file = "0.2.0"
 clap = { version = "4.5.7", features = ["derive"] }
 mailparse = "0.16.0"
+percent-encoding ="2.3.2"
 
 [dev-dependencies]
 mockito = "1.7.0"

--- a/src/process/exec_utils.rs
+++ b/src/process/exec_utils.rs
@@ -1,3 +1,5 @@
+use crate::common::error_model::Error;
+use percent_encoding::percent_decode_str;
 use std::process::Command;
 
 pub fn is_executor_present(executor: &str) -> bool {
@@ -5,4 +7,11 @@ pub fn is_executor_present(executor: &str) -> bool {
         .spawn()
         .map(|mut child| child.kill().is_ok())
         .unwrap_or(false)
+}
+
+pub fn decode_filename(name: &str) -> Result<String, Error> {
+    percent_decode_str(name)
+        .decode_utf8()
+        .map(|cow| cow.into_owned())
+        .map_err(|err| Error::Internal(format!("Invalid filename: {}", err)))
 }

--- a/src/tests/api/manage_inject.rs
+++ b/src/tests/api/manage_inject.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::process::exec_utils::decode_filename;
     use mockito;
     use std::{env, fs};
     use std::io::Read;
@@ -43,7 +44,13 @@ mod tests {
         let current_exe_path = env::current_exe().unwrap();
         let parent_path = current_exe_path.parent().unwrap();
         let folder_name = parent_path.file_name().unwrap().to_str().unwrap();
-        let payloads_path = parent_path.parent().unwrap().parent().unwrap().join("payloads").join(folder_name);
+        let payloads_path = parent_path
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("payloads")
+            .join(folder_name);
         create_dir_all(payloads_path).expect("Cannot create payloads directory");
 
         let mut server = mockito::Server::new();
@@ -76,7 +83,13 @@ mod tests {
         let current_exe_path = std::env::current_exe().unwrap();
         let parent_path = current_exe_path.parent().unwrap();
         let folder_name = parent_path.file_name().unwrap().to_str().unwrap();
-        let payloads_path = parent_path.parent().unwrap().parent().unwrap().join("payloads").join(folder_name);
+        let payloads_path = parent_path
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("payloads")
+            .join(folder_name);
         let expected_file_path = payloads_path.join(filename);
 
         assert!(expected_file_path.exists());
@@ -88,5 +101,79 @@ mod tests {
 
         // -- CLEAN --
         fs::remove_file(expected_file_path).unwrap();
+    }
+
+    #[test]
+    fn test_decode_file_name() {
+        let names: Vec<(String, String)> = vec![
+            (
+                "rapport%20final.pdf".to_string(),
+                "rapport final.pdf".to_string(),
+            ),
+            (
+                "photo_%C3%A9t%C3%A9.jpeg".to_string(),
+                "photo_été.jpeg".to_string(),
+            ),
+            (
+                "notes%20%28version%202%29.txt".to_string(),
+                "notes (version 2).txt".to_string(),
+            ),
+            (
+                "r%C3%A9sum%C3%A9%F0%9F%93%84.docx".to_string(),
+                "résumé📄.docx".to_string(),
+            ),
+            (
+                "code-source%231.rs".to_string(),
+                "code-source#1.rs".to_string(),
+            ),
+            (
+                "donn%C3%A9es_brutes.csv".to_string(),
+                "données_brutes.csv".to_string(),
+            ),
+            (
+                "archive-2025%21.zip".to_string(),
+                "archive-2025!.zip".to_string(),
+            ),
+            (
+                "%F0%9F%8E%B5_musique.mp3".to_string(),
+                "🎵_musique.mp3".to_string(),
+            ),
+            ("image%402x.png".to_string(), "image@2x.png".to_string()),
+            (
+                "backup%26save.tar.gz".to_string(),
+                "backup&save.tar.gz".to_string(),
+            ),
+            (
+                "%ED%9A%8C%EC%9D%98%EB%A1%9D.docx".to_string(),
+                "회의록.docx".to_string(),
+            ),
+            (
+                "%EC%82%AC%EC%A7%84_%EC%97%AC%EB%A6%84.png".to_string(),
+                "사진_여름.png".to_string(),
+            ),
+            (
+                "%EC%9D%8C%EC%95%85%F0%9F%8E%B6.mp3".to_string(),
+                "음악🎶.mp3".to_string(),
+            ),
+            ("%E6%8A%A5%E5%91%8A.pdf".to_string(), "报告.pdf".to_string()),
+            (
+                "%E7%85%A7%E7%89%87_%E5%A4%8F%E5%A4%A9.jpg".to_string(),
+                "照片_夏天.jpg".to_string(),
+            ),
+            (
+                "%E9%9F%B3%E4%B9%90%E6%96%87%E4%BB%B6.mp3".to_string(),
+                "音乐文件.mp3".to_string(),
+            ),
+        ];
+        for (key, value) in &names {
+            assert!(decode_filename(key).unwrap().eq(value))
+        }
+    }
+
+    #[test]
+    fn test_decode_invalid_filename() {
+        let input = "%FF%20file.txt";
+        let result = decode_filename(input);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* File name is encoded into the "Content-Disposition header" to ensure the respect of rules RFC 2616/6266 for the OpenBas's API /api/documents/{documentId}/file
* To secure the usage of the file inject into the endpoint the filename is decoded into the implant side

### Related issues

* Close #3846
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [X] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
